### PR TITLE
Reorder CSS properties order rules

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -15,39 +15,69 @@ module.exports = {
     }],
     'function-comma-space-after': null,
     'order/properties-order': [
+      // NOTE: Order is inspired by general rules from https://9elements.com/css-rule-order
+      // Generated content
       'content',
-      'display',
+
+      // Position and layout
       'position',
+      'z-index',
       'top',
       'right',
       'bottom',
       'left',
+      'float',
+
+      // Display and visibility
+      'display',
+      'opacity',
       'transform',
+
+      // Clipping
+      'overflow',
+      'clip',
+
+      // Animation
+      'animation',
+      'transition',
+
+      // Box model
+      'margin',
+      'margin-top',
+      'margin-right',
+      'margin-bottom',
+      'margin-left',
+      'box-shadow',
+      'border',
+      'border-radius',
+      'box-sizing',
       'width',
       'min-width',
       'max-width',
       'height',
       'min-height',
       'max-height',
-      'margin',
-      'margin-top',
-      'margin-right',
-      'margin-bottom',
-      'margin-left',
       'padding',
       'padding-top',
       'padding-right',
       'padding-bottom',
       'padding-left',
-      'color',
-      'font-size',
-      'font-weight',
-      'line-height',
-      'text-transform',
+
+      // Background
       'background',
       'background-color',
-      'border',
-      'cursor'
+      'cursor',
+
+      // Typography
+      'font-size',
+      'line-height',
+      'font-family',
+      'font-weight',
+      'font-style',
+      'text-align',
+      'text-transform',
+      'word-spacing',
+      'color'
     ]
   }
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -54,7 +54,7 @@ describe('reports warnings for invalid css', () => {
 
   it('with correct warning text', () => {
     return result.then(data => (
-      expect(data.results[0].warnings[0].text).toBe('Expected "display" to come before "position" (order/properties-order)')
+      expect(data.results[0].warnings[0].text).toBe('Expected "position" to come before "display" (order/properties-order)')
     ));
   });
 });

--- a/tests/invalid.css
+++ b/tests/invalid.css
@@ -1,4 +1,4 @@
 div {
-  position: relative;
   display: none;
+  position: relative;
 }

--- a/tests/valid.css
+++ b/tests/valid.css
@@ -1,4 +1,4 @@
 div {
-  display: none;
   position: relative;
+  display: none;
 }


### PR DESCRIPTION
Changed the macro order to be:
`position > display > box model > background > typography`

Changed the box model order to be outside-in:
`margin > border > width/height > padding`

Order changes inspired by general rules found on
https://9elements.com/css-rule-order/

For posterity here are the general rules:
```
1. From most important to less important. So what is important? 
Rules that affect the layout and the box size. What happens inside of the box and 
does not affect the layout/size is less important.

2. Group properties that belong together in terms of the CSS specification: 
Positioning, float/clear, font-*, text-*

3.Order of CSS layouting as defined in the CSS specification:
position: absolute may override float: left/right. float: left/right may override display, 
with the exception of display: none. So the order is: position, float, display.
Text is laid out in line boxes, then words, then glyphs. So properties for font-size 
and line-height come first, then text-*, then word-*.

4. Order by box model, start at the outer edge and move inward

5. Clockwise longhand order: *-top, *-right, *-bottom, *-left
```

I've also added a few frequent properties that were missing from the order rules.