### PR TITLE
Support SCSS syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ license](https://badgen.net/github/license/ExtensionEngine/stylelint-config)](ht
 [![js @extensionengine
 style](https://badgen.net/badge/code%20style/@extensionengine/black)](https://github.com/ExtensionEngine/eslint-config)
 
-This package provides Extension Engine's extensible stylelint config.
+This package provides Extension Engine's extensible Stylelint config.
 
 ## Usage
 
-Configuration supports `css` and `scss`.
+Package contains two shared Stylelint configs:
+
+### @extensionengine/stylelint-config
+
+This is default configuration supporting `css`, `scss` and Vue.
+
+### @extensionengine/stylelint-config/base
+
+This is base configuration without Vue specific rules.
 
 ### Install
 
@@ -32,7 +40,7 @@ npx install-peerdeps -D @extensionengine/stylelint-config
 or the classic way:
 
 ```
-npm install --save-dev stylelint @extensionengine/stylelint-config
+npm install --save-dev postcss-html postcss-scss stylelint @extensionengine/stylelint-config
 ```
 
 ### Using `@extensionengine/stylelint-config` in your project
@@ -44,6 +52,16 @@ In your local `stylelint.config.js` extend this configuration
 
 module.exports = {
   extends: '@extensionengine/stylelint-config'
+};
+```
+
+If you don't need Vue you can use base configuration:
+
+```js
+'use strict';
+
+module.exports = {
+  extends: '@extensionengine/stylelint-config/base'
 };
 ```
 

--- a/base.js
+++ b/base.js
@@ -6,7 +6,6 @@
 module.exports = {
   extends: [
     'stylelint-config-standard-scss',
-    'stylelint-config-recommended-vue',
     './rules/base'
   ],
   plugins: ['stylelint-order']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@extensionengine/stylelint-config",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@extensionengine/stylelint-config",
-      "version": "3.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "stylelint-config-recommended-vue": "^1.5.0",
@@ -14,9 +14,9 @@
         "stylelint-order": "^6.0.3"
       },
       "devDependencies": {
-        "@babel/eslint-parser": "^7.22.6",
+        "@babel/eslint-parser": "^7.22.7",
         "@babel/eslint-plugin": "^7.22.5",
-        "@extensionengine/eslint-config": "^3.0.1",
+        "@extensionengine/eslint-config": "^4.0.0",
         "@types/stylelint": "^13.13.3",
         "eslint": "^8.44.0",
         "eslint-config-semistandard": "^17.0.0",
@@ -27,12 +27,14 @@
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-standard": "^4.1.0",
         "eslint-plugin-vue": "^9.15.1",
-        "jest": "^29.6.0",
+        "jest": "^29.6.1",
         "jest-preset-stylelint": "^6.1.0",
-        "stylelint": "^15.10.0"
+        "stylelint": "^15.10.1"
       },
       "peerDependencies": {
-        "stylelint": ">=15.10.0"
+        "postcss-html": ">=1.5.0",
+        "postcss-scss": ">=4.0.6",
+        "stylelint": ">=15.10.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -108,9 +110,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.6.tgz",
-      "integrity": "sha512-KAom7E7d6bAh5/PflF3luynWlDLOIqfX+ZJcL0LRs6/6rtXJmJxPiWuIGfxNPtcWdtQ5lSSJbKbQlz/c/R60Ng==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.7.tgz",
+      "integrity": "sha512-LH6HJqjOyu/Qtp7LuSycZXK/CYXQ4ohdkliEaL1QTdtOXVdOVpTBKVxAo/+eeyt+x/2SRzB+zUPduVl+xiEvdg==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -751,21 +753,21 @@
       }
     },
     "node_modules/@extensionengine/eslint-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@extensionengine/eslint-config/-/eslint-config-3.0.1.tgz",
-      "integrity": "sha512-zzgJ5Q11JCi6acE0U5+5OZiLJlBt29CanGuMj5HxbhijJDFaJCpU42mEScOUB/miHeywc27lsXVMPnmFgqGPVw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@extensionengine/eslint-config/-/eslint-config-4.0.0.tgz",
+      "integrity": "sha512-ueKqBdwohc+4KJxDogvp/bqBoNOF3ePQpvOunfeUpDNGO5xmQGV/DrlVqFQDy0SZ7KlbA8FPTFHGzUD2gQKVWA==",
       "dev": true,
       "peerDependencies": {
-        "@babel/eslint-parser": ">=7.14.7",
-        "@babel/eslint-plugin": ">=7.14.5",
-        "eslint": ">=7.29.0",
-        "eslint-config-semistandard": ">=16.0.0",
-        "eslint-config-standard": ">=16.0.3",
-        "eslint-plugin-import": ">=2.23.4",
+        "@babel/eslint-parser": ">=7.22.6",
+        "@babel/eslint-plugin": ">=7.22.5",
+        "eslint": ">=8.44.0",
+        "eslint-config-semistandard": ">=7.0.0",
+        "eslint-config-standard": ">=17.1.0",
+        "eslint-plugin-import": ">=2.27.5",
         "eslint-plugin-node": ">=11.1.0",
-        "eslint-plugin-promise": ">=5.1.0",
-        "eslint-plugin-require-sort": ">=1.2.2",
-        "eslint-plugin-vue": ">=6.2.2"
+        "eslint-plugin-promise": ">=6.1.1",
+        "eslint-plugin-require-sort": ">=1.3.0",
+        "eslint-plugin-vue": ">=9.15.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -910,16 +912,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.0.tgz",
-      "integrity": "sha512-anb6L1yg7uPQpytNVA5skRaXy3BmrsU8icRhTVNbWdjYWDDfy8M1Kq5HIVRpYoABdbpqsc5Dr+jtu4+qWRQBiQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
+      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -997,16 +999,16 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.0.tgz",
-      "integrity": "sha512-5dbMHfY/5R9m8NbgmB3JlxQqooZ/ooPSOiwEQZZ+HODwJTbIu37seVcZNBK29aMdXtjvTRB3f6LCvkKq+r8uQA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
+      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.0",
-        "@jest/reporters": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/reporters": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
@@ -1014,20 +1016,20 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.0",
-        "jest-haste-map": "^29.6.0",
-        "jest-message-util": "^29.6.0",
+        "jest-config": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-resolve-dependencies": "^29.6.0",
-        "jest-runner": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
-        "jest-watcher": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-resolve-dependencies": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
+        "jest-watcher": "^29.6.1",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -1114,37 +1116,37 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.0.tgz",
-      "integrity": "sha512-bUZLYUxYlUIsslBbxII0fq0kr1+friI3Gty+cRLmocGB1jdcAHs7FS8QdCDqedE8q4DZE1g/AJHH6OJZBLGGsg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.0"
+        "jest-mock": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.0.tgz",
-      "integrity": "sha512-a7pISPW28Q3c0/pLwz4mQ6tbAI+hc8/0CJp9ix6e9U4dQ6TiHQX82CT5DV5BMWaw8bFH4E6zsfZxXdn6Ka23Bw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.6.0",
-        "jest-snapshot": "^29.6.0"
+        "expect": "^29.6.1",
+        "jest-snapshot": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.0.tgz",
-      "integrity": "sha512-LLSQQN7oypMSETKoPWpsWYVKJd9LQWmSDDAc4hUQ4JocVC7LAMy9R3ZMhlnLwbcFvQORZnZR7HM893Px6cJhvA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
+      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3"
@@ -1154,48 +1156,48 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.0.tgz",
-      "integrity": "sha512-nuCU46AsZoskthWSDS2Aj6LARgyNcp5Fjx2qxsO/fPl1Wp1CJ+dBDqs0OkEcJK8FBeV/MbjH5efe79M2sHcV+A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.0",
-        "jest-mock": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.0.tgz",
-      "integrity": "sha512-IQQ3hZ2D/hwEwXSMv5GbfhzdH0nTQR3KPYxnuW6gYWbd6+7/zgMz7Okn6EgBbNtJNONq03k5EKA6HqGyzRbpeg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.0",
-        "@jest/expect": "^29.6.0",
-        "@jest/types": "^29.6.0",
-        "jest-mock": "^29.6.0"
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "jest-mock": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.0.tgz",
-      "integrity": "sha512-dWEq4HI0VvHcAD6XTtyBKKARLytyyWPIy1SvGOcU91106MfvHPdxZgupFwVHd8TFpZPpA3SebYjtwS5BUS76Rw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -1208,9 +1210,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1325,13 +1327,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.0.tgz",
-      "integrity": "sha512-9qLb7xITeyWhM4yatn2muqfomuoCTOhv0QV9i7XiIyYi3QLfnvPv5NeJp5u0PZeutAOROMLKakOkmoAisOr3YQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -1340,14 +1342,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.0.tgz",
-      "integrity": "sha512-HYCS3LKRQotKWj2mnA3AN13PPevYZu8MJKm12lzYojpJNnn6kI/3PWmr1At/e3tUu+FHQDiOyaDVuR4EV3ezBw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1355,22 +1357,22 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.0.tgz",
-      "integrity": "sha512-bhP/KxPo3e322FJ0nKAcb6WVK76ZYyQd1lWygJzoSqP8SYMSLdxHqP4wnPTI4WvbB8PKPDV30y5y7Tya4RHOBA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1457,9 +1459,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.0.tgz",
-      "integrity": "sha512-8XCgL9JhqbJTFnMRjEAO+TuW251+MoMd5BSzLiE3vvzpQ8RlBxy8NoyNkDhs3K3OL3HeVinlOl9or5p7GTeOLg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.0",
@@ -1763,9 +1765,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -2211,12 +2213,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.0.tgz",
-      "integrity": "sha512-Jj8Bq2yKsk11XLk06Nm8SdvYkAcecH+GuhxB8DnK5SncjHnJ88TQjSnGgE7jpajpnSvz9DZ6X8hXrDkD/6/TPQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.6.0",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -2520,21 +2522,45 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2756,11 +2782,14 @@
       }
     },
     "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decamelize-keys": {
@@ -2776,6 +2805,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decamelize-keys/node_modules/map-obj": {
@@ -3875,17 +3912,17 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.0.tgz",
-      "integrity": "sha512-AV+HaBtnDJ2YEUhPPo25HyUHBLaetM+y/Dq6pEC8VPQyt1dK+k8MfGkMy46djy2bddcqESc1kl4/K1uLWSfk9g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.6.0",
+        "@jest/expect-utils": "^29.6.1",
         "@types/node": "*",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3985,7 +4022,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -4486,11 +4522,14 @@
       }
     },
     "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -4901,15 +4940,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.0.tgz",
-      "integrity": "sha512-do1J9gGrQ68E4UfMz/4OM71p9qCqQxu32N/9ZfeYFSSlx0uUOuxeyZxtJZNaUTW12ZA11ERhmBjBhy1Ho96R4g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
+      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/core": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.0"
+        "jest-cli": "^29.6.1"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -4940,28 +4979,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.0.tgz",
-      "integrity": "sha512-LtG45qEKhse2Ws5zNR4DnZATReLGQXzBZGZnJ0DU37p6d4wDhu41vvczCQ3Ou+llR6CRYDBshsubV7H4jZvIkw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
+      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.0",
-        "@jest/expect": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.0",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-each": "^29.6.1",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -5041,21 +5080,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.0.tgz",
-      "integrity": "sha512-WvZIaanK/abkw6s01924DQ2QLwM5Q4Y4iPbSDb9Zg6smyXGqqcPQ7ft9X8D7B0jICz312eSzM6UlQNxuZJBrMw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
+      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/core": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-config": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -5145,31 +5184,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.0.tgz",
-      "integrity": "sha512-fKA4jM91PDqWVkMpb1FVKxIuhg3hC6hgaen57cr1rRZkR96dCatvJZsk3ik7/GNu9ERj9wgAspOmyvkFoGsZhA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
+      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.0",
-        "@jest/types": "^29.6.0",
-        "babel-jest": "^29.6.0",
+        "@jest/test-sequencer": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "babel-jest": "^29.6.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.0",
-        "jest-environment-node": "^29.6.0",
+        "jest-circus": "^29.6.1",
+        "jest-environment-node": "^29.6.1",
         "jest-get-type": "^29.4.3",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-runner": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -5260,15 +5299,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.0.tgz",
-      "integrity": "sha512-ZRm7cd2m9YyZ0N3iMyuo1iUiprxQ/MFpYWXzEEj7hjzL3WnDffKW8192XBDcrAI8j7hnrM1wed3bL/oEnYF/8w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
+      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.4.3",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5357,16 +5396,16 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.0.tgz",
-      "integrity": "sha512-d0Jem4RBAlFUyV6JSXPSHVUpNo5RleSj+iJEy1G3+ZCrzHDjWs/1jUfrbnJKHdJdAx5BCEce/Ju379WqHhQk4w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
+      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
-        "jest-util": "^29.6.0",
-        "pretty-format": "^29.6.0"
+        "jest-util": "^29.6.1",
+        "pretty-format": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5443,17 +5482,17 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.0.tgz",
-      "integrity": "sha512-BOf5Q2/nFCdBOnyBM5c5/6DbdQYgc+0gyUQ8l8qhUAB8O7pM+4QJXIXJsRZJaxd5SHV6y5VArTVhOfogoqcP8Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
+      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.0",
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5469,20 +5508,20 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.0.tgz",
-      "integrity": "sha512-dY1DKufptj7hcJSuhpqlYPGcnN3XjlOy/g0jinpRTMsbb40ivZHiuIPzeminOZkrek8C+oDxC54ILGO3vMLojg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -5494,28 +5533,28 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.0.tgz",
-      "integrity": "sha512-JdV6EZOPxHR1gd6ccxjNowuROkT2jtGU5G/g58RcJX1xe5mrtLj0g6/ZkyMoXF4cs+tTkHMFX6pcIrB1QPQwCw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
+      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.0.tgz",
-      "integrity": "sha512-oSlqfGN+sbkB2Q5um/zL7z80w84FEAcLKzXBZIPyRk2F2Srg1ubhrHVKW68JCvb2+xKzAeGw35b+6gciS24PHw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
+      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.0",
+        "jest-diff": "^29.6.1",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5592,18 +5631,18 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.0.tgz",
-      "integrity": "sha512-mkCp56cETbpoNtsaeWVy6SKzk228mMi9FPHSObaRIhbR2Ujw9PqjW/yqVHD2tN1bHbC8ol6h3UEo7dOPmIYwIA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
+      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5682,14 +5721,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.0.tgz",
-      "integrity": "sha512-2Pb7R2w24Q0aUVn+2/vdRDL6CqGqpheDZy7zrXav8FotOpSGw/4bS2hyVoKHMEx4xzOn6EyCAGwc5czWxXeN7w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
+      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-util": "^29.6.0"
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5734,17 +5773,17 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.0.tgz",
-      "integrity": "sha512-+hrpY4LzAONoZA/rvB6rnZLkOSA6UgJLpdCWrOZNSgGxWMumzRLu7dLUSCabAHzoHIDQ9qXfr3th1zYNJ0E8sQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
+      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -5754,13 +5793,13 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.0.tgz",
-      "integrity": "sha512-eOfPog9K3hJdJk/3i6O6bQhXS+3uXhMDkLJGX+xmMPp7T1d/zdcFofbDnHgNoEkhD/mSimC5IagLEP7lpLLu/A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
+      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.6.0"
+        "jest-snapshot": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5837,30 +5876,30 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.0.tgz",
-      "integrity": "sha512-4fZuGV2lOxS2BiqEG9/AI8E6O+jo+QZjMVcgi1x5E6aDql0Gd/EFIbUQ0pSS09y8cya1vJB/qC2xsE468jqtSg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
+      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.0",
-        "@jest/environment": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/environment": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.6.0",
-        "jest-haste-map": "^29.6.0",
-        "jest-leak-detector": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-resolve": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-watcher": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-environment-node": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-leak-detector": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-resolve": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-watcher": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -5939,31 +5978,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.0.tgz",
-      "integrity": "sha512-5FavYo3EeXLHIvnJf+r7Cj0buePAbe4mzRB9oeVxDS0uVmouSBjWeGgyRjZkw7ArxOoZI8gO6f8SGMJ2HFlwwg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
+      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.0",
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/globals": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/globals": "^29.6.1",
         "@jest/source-map": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-mock": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -6042,9 +6081,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.0.tgz",
-      "integrity": "sha512-H3kUE9NwWDEDoutcOSS921IqdlkdjgnMdj1oMyxAHNflscdLc9dB8OudZHV6kj4OHJxbMxL8CdI5DlwYrs4wQg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
+      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -6052,21 +6091,21 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/expect-utils": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.0",
+        "expect": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.0",
+        "jest-diff": "^29.6.1",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -6144,9 +6183,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6177,12 +6216,12 @@
       "dev": true
     },
     "node_modules/jest-util": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.0.tgz",
-      "integrity": "sha512-S0USx9YwcvEm4pQ5suisVm/RVxBmi0GFR7ocJhIeaCuW5AXnAnffXbaVKvIFodyZNOc9ygzVtTxmBf40HsHXaA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -6264,17 +6303,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.0.tgz",
-      "integrity": "sha512-MLTrAJsb1+W7svbeZ+A7pAnyXMaQrjvPDKCy7OlfsfB6TMVc69v7WjUWfiR6r3snULFWZASiKgvNVDuATta1dg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
+      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6363,18 +6402,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.0.tgz",
-      "integrity": "sha512-LdsQqFNX60mRdRRe+zsELnYRH1yX6KL+ukbh+u6WSQeTheZZe1TlLJNKRQiZ7e0VbvMkywmMWL/KV35noOJCcw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
+      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -6452,13 +6491,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.0.tgz",
-      "integrity": "sha512-oiQHH1SnKmZIwwPnpOrXTq4kHBk3lKGY/07DpnH0sAu+x7J8rXlbLDROZsU6vy9GwB0hPiZeZpu6YlJ48QoKcA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -6600,7 +6639,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -6687,34 +6725,34 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+      "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
       "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
         "node": ">=10"
       },
@@ -6864,9 +6902,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7011,7 +7049,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -7026,7 +7063,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -7041,6 +7077,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7101,7 +7138,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7321,9 +7359,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.0.tgz",
-      "integrity": "sha512-XH+D4n7Ey0iSR6PdAnBs99cWMZdGsdKrR33iUHQNr79w1szKTCIZDVdXuccAsHVwDBp0XeWPfNEoaxP9EZgRmQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.0",
@@ -7403,11 +7441,14 @@
       ]
     },
     "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-is": {
@@ -7417,133 +7458,73 @@
       "dev": true
     },
     "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -7596,6 +7577,7 @@
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -7998,14 +7980,17 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "dependencies": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8026,9 +8011,9 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "node_modules/stylelint": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.0.tgz",
-      "integrity": "sha512-uDCwoZA+C2Ee29wEFi8irICpH+wie1Ku/57QrWKqtKh+ZE1LuVDkUQUg9Zp3WlWMu8IABXxFaFj3/szy+SRc0Q==",
+      "version": "15.10.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
+      "integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.3.0",
         "@csstools/css-tokenizer": "^2.1.1",
@@ -8053,7 +8038,7 @@
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
-        "meow": "^9.0.0",
+        "meow": "^10.1.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
@@ -8072,7 +8057,7 @@
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
-        "stylelint": "bin/stylelint.js"
+        "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
@@ -8338,6 +8323,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8432,11 +8418,14 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -8916,7 +8905,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -8980,9 +8968,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.6.tgz",
-      "integrity": "sha512-KAom7E7d6bAh5/PflF3luynWlDLOIqfX+ZJcL0LRs6/6rtXJmJxPiWuIGfxNPtcWdtQ5lSSJbKbQlz/c/R60Ng==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.7.tgz",
+      "integrity": "sha512-LH6HJqjOyu/Qtp7LuSycZXK/CYXQ4ohdkliEaL1QTdtOXVdOVpTBKVxAo/+eeyt+x/2SRzB+zUPduVl+xiEvdg==",
       "dev": true,
       "requires": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -9409,9 +9397,9 @@
       "dev": true
     },
     "@extensionengine/eslint-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@extensionengine/eslint-config/-/eslint-config-3.0.1.tgz",
-      "integrity": "sha512-zzgJ5Q11JCi6acE0U5+5OZiLJlBt29CanGuMj5HxbhijJDFaJCpU42mEScOUB/miHeywc27lsXVMPnmFgqGPVw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@extensionengine/eslint-config/-/eslint-config-4.0.0.tgz",
+      "integrity": "sha512-ueKqBdwohc+4KJxDogvp/bqBoNOF3ePQpvOunfeUpDNGO5xmQGV/DrlVqFQDy0SZ7KlbA8FPTFHGzUD2gQKVWA==",
       "dev": true,
       "requires": {}
     },
@@ -9522,16 +9510,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.0.tgz",
-      "integrity": "sha512-anb6L1yg7uPQpytNVA5skRaXy3BmrsU8icRhTVNbWdjYWDDfy8M1Kq5HIVRpYoABdbpqsc5Dr+jtu4+qWRQBiQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
+      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -9587,16 +9575,16 @@
       }
     },
     "@jest/core": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.0.tgz",
-      "integrity": "sha512-5dbMHfY/5R9m8NbgmB3JlxQqooZ/ooPSOiwEQZZ+HODwJTbIu37seVcZNBK29aMdXtjvTRB3f6LCvkKq+r8uQA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
+      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.0",
-        "@jest/reporters": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/reporters": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
@@ -9604,20 +9592,20 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.0",
-        "jest-haste-map": "^29.6.0",
-        "jest-message-util": "^29.6.0",
+        "jest-config": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-resolve-dependencies": "^29.6.0",
-        "jest-runner": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
-        "jest-watcher": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-resolve-dependencies": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
+        "jest-watcher": "^29.6.1",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -9674,73 +9662,73 @@
       }
     },
     "@jest/environment": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.0.tgz",
-      "integrity": "sha512-bUZLYUxYlUIsslBbxII0fq0kr1+friI3Gty+cRLmocGB1jdcAHs7FS8QdCDqedE8q4DZE1g/AJHH6OJZBLGGsg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.0"
+        "jest-mock": "^29.6.1"
       }
     },
     "@jest/expect": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.0.tgz",
-      "integrity": "sha512-a7pISPW28Q3c0/pLwz4mQ6tbAI+hc8/0CJp9ix6e9U4dQ6TiHQX82CT5DV5BMWaw8bFH4E6zsfZxXdn6Ka23Bw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
       "dev": true,
       "requires": {
-        "expect": "^29.6.0",
-        "jest-snapshot": "^29.6.0"
+        "expect": "^29.6.1",
+        "jest-snapshot": "^29.6.1"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.0.tgz",
-      "integrity": "sha512-LLSQQN7oypMSETKoPWpsWYVKJd9LQWmSDDAc4hUQ4JocVC7LAMy9R3ZMhlnLwbcFvQORZnZR7HM893Px6cJhvA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
+      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
       "dev": true,
       "requires": {
         "jest-get-type": "^29.4.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.0.tgz",
-      "integrity": "sha512-nuCU46AsZoskthWSDS2Aj6LARgyNcp5Fjx2qxsO/fPl1Wp1CJ+dBDqs0OkEcJK8FBeV/MbjH5efe79M2sHcV+A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.0",
-        "jest-mock": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "@jest/globals": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.0.tgz",
-      "integrity": "sha512-IQQ3hZ2D/hwEwXSMv5GbfhzdH0nTQR3KPYxnuW6gYWbd6+7/zgMz7Okn6EgBbNtJNONq03k5EKA6HqGyzRbpeg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.0",
-        "@jest/expect": "^29.6.0",
-        "@jest/types": "^29.6.0",
-        "jest-mock": "^29.6.0"
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "jest-mock": "^29.6.1"
       }
     },
     "@jest/reporters": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.0.tgz",
-      "integrity": "sha512-dWEq4HI0VvHcAD6XTtyBKKARLytyyWPIy1SvGOcU91106MfvHPdxZgupFwVHd8TFpZPpA3SebYjtwS5BUS76Rw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -9753,9 +9741,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -9834,46 +9822,46 @@
       }
     },
     "@jest/test-result": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.0.tgz",
-      "integrity": "sha512-9qLb7xITeyWhM4yatn2muqfomuoCTOhv0QV9i7XiIyYi3QLfnvPv5NeJp5u0PZeutAOROMLKakOkmoAisOr3YQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.0.tgz",
-      "integrity": "sha512-HYCS3LKRQotKWj2mnA3AN13PPevYZu8MJKm12lzYojpJNnn6kI/3PWmr1At/e3tUu+FHQDiOyaDVuR4EV3ezBw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "slash": "^3.0.0"
       }
     },
     "@jest/transform": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.0.tgz",
-      "integrity": "sha512-bhP/KxPo3e322FJ0nKAcb6WVK76ZYyQd1lWygJzoSqP8SYMSLdxHqP4wnPTI4WvbB8PKPDV30y5y7Tya4RHOBA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -9938,9 +9926,9 @@
       }
     },
     "@jest/types": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.0.tgz",
-      "integrity": "sha512-8XCgL9JhqbJTFnMRjEAO+TuW251+MoMd5BSzLiE3vvzpQ8RlBxy8NoyNkDhs3K3OL3HeVinlOl9or5p7GTeOLg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.6.0",
@@ -10203,9 +10191,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -10522,12 +10510,12 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.0.tgz",
-      "integrity": "sha512-Jj8Bq2yKsk11XLk06Nm8SdvYkAcecH+GuhxB8DnK5SncjHnJ88TQjSnGgE7jpajpnSvz9DZ6X8hXrDkD/6/TPQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^29.6.0",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -10754,16 +10742,30 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
       "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
+        "camelcase": "^6.3.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+        },
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
       }
     },
     "caniuse-lite": {
@@ -10913,9 +10915,9 @@
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
     },
     "decamelize-keys": {
       "version": "1.1.1",
@@ -10926,6 +10928,11 @@
         "map-obj": "^1.0.0"
       },
       "dependencies": {
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+        },
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -11693,17 +11700,17 @@
       "dev": true
     },
     "expect": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.0.tgz",
-      "integrity": "sha512-AV+HaBtnDJ2YEUhPPo25HyUHBLaetM+y/Dq6pEC8VPQyt1dK+k8MfGkMy46djy2bddcqESc1kl4/K1uLWSfk9g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.6.0",
+        "@jest/expect-utils": "^29.6.1",
         "@types/node": "*",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "fast-deep-equal": {
@@ -11787,7 +11794,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -12132,9 +12138,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -12423,15 +12429,15 @@
       }
     },
     "jest": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.0.tgz",
-      "integrity": "sha512-do1J9gGrQ68E4UfMz/4OM71p9qCqQxu32N/9ZfeYFSSlx0uUOuxeyZxtJZNaUTW12ZA11ERhmBjBhy1Ho96R4g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
+      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/core": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.0"
+        "jest-cli": "^29.6.1"
       }
     },
     "jest-changed-files": {
@@ -12445,28 +12451,28 @@
       }
     },
     "jest-circus": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.0.tgz",
-      "integrity": "sha512-LtG45qEKhse2Ws5zNR4DnZATReLGQXzBZGZnJ0DU37p6d4wDhu41vvczCQ3Ou+llR6CRYDBshsubV7H4jZvIkw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
+      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.0",
-        "@jest/expect": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.0",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-each": "^29.6.1",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -12524,21 +12530,21 @@
       }
     },
     "jest-cli": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.0.tgz",
-      "integrity": "sha512-WvZIaanK/abkw6s01924DQ2QLwM5Q4Y4iPbSDb9Zg6smyXGqqcPQ7ft9X8D7B0jICz312eSzM6UlQNxuZJBrMw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
+      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/core": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-config": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -12595,31 +12601,31 @@
       }
     },
     "jest-config": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.0.tgz",
-      "integrity": "sha512-fKA4jM91PDqWVkMpb1FVKxIuhg3hC6hgaen57cr1rRZkR96dCatvJZsk3ik7/GNu9ERj9wgAspOmyvkFoGsZhA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
+      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.0",
-        "@jest/types": "^29.6.0",
-        "babel-jest": "^29.6.0",
+        "@jest/test-sequencer": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "babel-jest": "^29.6.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.0",
-        "jest-environment-node": "^29.6.0",
+        "jest-circus": "^29.6.1",
+        "jest-environment-node": "^29.6.1",
         "jest-get-type": "^29.4.3",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-runner": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -12676,15 +12682,15 @@
       }
     },
     "jest-diff": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.0.tgz",
-      "integrity": "sha512-ZRm7cd2m9YyZ0N3iMyuo1iUiprxQ/MFpYWXzEEj7hjzL3WnDffKW8192XBDcrAI8j7hnrM1wed3bL/oEnYF/8w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
+      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.4.3",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12748,16 +12754,16 @@
       }
     },
     "jest-each": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.0.tgz",
-      "integrity": "sha512-d0Jem4RBAlFUyV6JSXPSHVUpNo5RleSj+iJEy1G3+ZCrzHDjWs/1jUfrbnJKHdJdAx5BCEce/Ju379WqHhQk4w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
+      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
-        "jest-util": "^29.6.0",
-        "pretty-format": "^29.6.0"
+        "jest-util": "^29.6.1",
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12812,17 +12818,17 @@
       }
     },
     "jest-environment-node": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.0.tgz",
-      "integrity": "sha512-BOf5Q2/nFCdBOnyBM5c5/6DbdQYgc+0gyUQ8l8qhUAB8O7pM+4QJXIXJsRZJaxd5SHV6y5VArTVhOfogoqcP8Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
+      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.0",
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.0",
-        "jest-util": "^29.6.0"
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "jest-get-type": {
@@ -12832,12 +12838,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.0.tgz",
-      "integrity": "sha512-dY1DKufptj7hcJSuhpqlYPGcnN3XjlOy/g0jinpRTMsbb40ivZHiuIPzeminOZkrek8C+oDxC54ILGO3vMLojg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -12845,32 +12851,32 @@
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
     },
     "jest-leak-detector": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.0.tgz",
-      "integrity": "sha512-JdV6EZOPxHR1gd6ccxjNowuROkT2jtGU5G/g58RcJX1xe5mrtLj0g6/ZkyMoXF4cs+tTkHMFX6pcIrB1QPQwCw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
+      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
       "dev": true,
       "requires": {
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       }
     },
     "jest-matcher-utils": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.0.tgz",
-      "integrity": "sha512-oSlqfGN+sbkB2Q5um/zL7z80w84FEAcLKzXBZIPyRk2F2Srg1ubhrHVKW68JCvb2+xKzAeGw35b+6gciS24PHw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
+      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.0",
+        "jest-diff": "^29.6.1",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12925,18 +12931,18 @@
       }
     },
     "jest-message-util": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.0.tgz",
-      "integrity": "sha512-mkCp56cETbpoNtsaeWVy6SKzk228mMi9FPHSObaRIhbR2Ujw9PqjW/yqVHD2tN1bHbC8ol6h3UEo7dOPmIYwIA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
+      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -12993,14 +12999,14 @@
       }
     },
     "jest-mock": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.0.tgz",
-      "integrity": "sha512-2Pb7R2w24Q0aUVn+2/vdRDL6CqGqpheDZy7zrXav8FotOpSGw/4bS2hyVoKHMEx4xzOn6EyCAGwc5czWxXeN7w==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
+      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-util": "^29.6.0"
+        "jest-util": "^29.6.1"
       }
     },
     "jest-pnp-resolver": {
@@ -13024,17 +13030,17 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.0.tgz",
-      "integrity": "sha512-+hrpY4LzAONoZA/rvB6rnZLkOSA6UgJLpdCWrOZNSgGxWMumzRLu7dLUSCabAHzoHIDQ9qXfr3th1zYNJ0E8sQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
+      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.0",
-        "jest-validate": "^29.6.0",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -13092,40 +13098,40 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.0.tgz",
-      "integrity": "sha512-eOfPog9K3hJdJk/3i6O6bQhXS+3uXhMDkLJGX+xmMPp7T1d/zdcFofbDnHgNoEkhD/mSimC5IagLEP7lpLLu/A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
+      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
       "dev": true,
       "requires": {
         "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.6.0"
+        "jest-snapshot": "^29.6.1"
       }
     },
     "jest-runner": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.0.tgz",
-      "integrity": "sha512-4fZuGV2lOxS2BiqEG9/AI8E6O+jo+QZjMVcgi1x5E6aDql0Gd/EFIbUQ0pSS09y8cya1vJB/qC2xsE468jqtSg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
+      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.0",
-        "@jest/environment": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/console": "^29.6.1",
+        "@jest/environment": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.6.0",
-        "jest-haste-map": "^29.6.0",
-        "jest-leak-detector": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-resolve": "^29.6.0",
-        "jest-runtime": "^29.6.0",
-        "jest-util": "^29.6.0",
-        "jest-watcher": "^29.6.0",
-        "jest-worker": "^29.6.0",
+        "jest-environment-node": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-leak-detector": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-resolve": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-watcher": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -13182,31 +13188,31 @@
       }
     },
     "jest-runtime": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.0.tgz",
-      "integrity": "sha512-5FavYo3EeXLHIvnJf+r7Cj0buePAbe4mzRB9oeVxDS0uVmouSBjWeGgyRjZkw7ArxOoZI8gO6f8SGMJ2HFlwwg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
+      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.0",
-        "@jest/fake-timers": "^29.6.0",
-        "@jest/globals": "^29.6.0",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/globals": "^29.6.1",
         "@jest/source-map": "^29.6.0",
-        "@jest/test-result": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-mock": "^29.6.0",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.0",
-        "jest-snapshot": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-resolve": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -13263,9 +13269,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.0.tgz",
-      "integrity": "sha512-H3kUE9NwWDEDoutcOSS921IqdlkdjgnMdj1oMyxAHNflscdLc9dB8OudZHV6kj4OHJxbMxL8CdI5DlwYrs4wQg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
+      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -13273,21 +13279,21 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.0",
-        "@jest/transform": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/expect-utils": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.0",
+        "expect": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.0",
+        "jest-diff": "^29.6.1",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.0",
-        "jest-message-util": "^29.6.0",
-        "jest-util": "^29.6.0",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.0",
+        "pretty-format": "^29.6.1",
         "semver": "^7.5.3"
       },
       "dependencies": {
@@ -13341,9 +13347,9 @@
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -13367,12 +13373,12 @@
       }
     },
     "jest-util": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.0.tgz",
-      "integrity": "sha512-S0USx9YwcvEm4pQ5suisVm/RVxBmi0GFR7ocJhIeaCuW5AXnAnffXbaVKvIFodyZNOc9ygzVtTxmBf40HsHXaA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -13432,17 +13438,17 @@
       }
     },
     "jest-validate": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.0.tgz",
-      "integrity": "sha512-MLTrAJsb1+W7svbeZ+A7pAnyXMaQrjvPDKCy7OlfsfB6TMVc69v7WjUWfiR6r3snULFWZASiKgvNVDuATta1dg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
+      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.6.0",
+        "@jest/types": "^29.6.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.0"
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13503,18 +13509,18 @@
       }
     },
     "jest-watcher": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.0.tgz",
-      "integrity": "sha512-LdsQqFNX60mRdRRe+zsELnYRH1yX6KL+ukbh+u6WSQeTheZZe1TlLJNKRQiZ7e0VbvMkywmMWL/KV35noOJCcw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
+      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.6.0",
-        "@jest/types": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "string-length": "^4.0.1"
       },
       "dependencies": {
@@ -13570,13 +13576,13 @@
       }
     },
     "jest-worker": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.0.tgz",
-      "integrity": "sha512-oiQHH1SnKmZIwwPnpOrXTq4kHBk3lKGY/07DpnH0sAu+x7J8rXlbLDROZsU6vy9GwB0hPiZeZpu6YlJ48QoKcA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "jest-util": "^29.6.0",
+        "jest-util": "^29.6.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -13681,7 +13687,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -13746,28 +13751,28 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+      "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
       "requires": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
@@ -13874,9 +13879,9 @@
           }
         },
         "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -13981,7 +13986,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -13990,7 +13994,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -13998,7 +14001,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -14038,7 +14042,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -14182,9 +14187,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.0.tgz",
-      "integrity": "sha512-XH+D4n7Ey0iSR6PdAnBs99cWMZdGsdKrR33iUHQNr79w1szKTCIZDVdXuccAsHVwDBp0XeWPfNEoaxP9EZgRmQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.6.0",
@@ -14227,9 +14232,9 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "react-is": {
       "version": "18.2.0",
@@ -14238,101 +14243,47 @@
       "dev": true
     },
     "read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
       },
       "dependencies": {
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
         "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
     "read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "requires": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
     "redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "requires": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
       }
     },
     "regexp.prototype.flags": {
@@ -14367,6 +14318,7 @@
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
@@ -14661,11 +14613,11 @@
       "dev": true
     },
     "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "requires": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       }
     },
     "strip-json-comments": {
@@ -14680,9 +14632,9 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.0.tgz",
-      "integrity": "sha512-uDCwoZA+C2Ee29wEFi8irICpH+wie1Ku/57QrWKqtKh+ZE1LuVDkUQUg9Zp3WlWMu8IABXxFaFj3/szy+SRc0Q==",
+      "version": "15.10.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
+      "integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
       "requires": {
         "@csstools/css-parser-algorithms": "^2.3.0",
         "@csstools/css-tokenizer": "^2.1.1",
@@ -14707,7 +14659,7 @@
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
-        "meow": "^9.0.0",
+        "meow": "^10.1.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
@@ -14903,7 +14855,8 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "svg-tags": {
       "version": "1.0.0",
@@ -14978,9 +14931,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ=="
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -15328,8 +15281,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@extensionengine/stylelint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@extensionengine/stylelint-config",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-standard": "^34.0.0",
-        "stylelint-order": "^6.0.3",
-        "stylelint-scss": "^5.0.1"
+        "stylelint-config-recommended-vue": "^1.5.0",
+        "stylelint-config-standard-scss": "^10.0.0",
+        "stylelint-order": "^6.0.3"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.22.6",
@@ -1801,6 +1801,29 @@
         "postcss": "7.x.x"
       }
     },
+    "node_modules/@types/stylelint/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/@types/stylelint/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -2841,6 +2864,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.416",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.416.tgz",
@@ -2863,6 +2941,18 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4310,6 +4400,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/human-signals": {
@@ -7092,28 +7201,98 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
-      "dev": true,
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-html": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.5.0.tgz",
+      "integrity": "sha512-kCMRWJRHKicpA166kc2lAVUGxDZL324bkj/pVOb6RhjB0Z5Krl7mN0AsVkBhVIRZZirY0lyQXG38HCVaoKVNoA==",
+      "peer": true,
+      "dependencies": {
+        "htmlparser2": "^8.0.0",
+        "js-tokens": "^8.0.0",
+        "postcss": "^8.4.0",
+        "postcss-safe-parser": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12 || >=14"
+      }
+    },
+    "node_modules/postcss-html/node_modules/js-tokens": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.1.tgz",
+      "integrity": "sha512-3AGrZT6tuMm1ZWWn9mLXh7XMfi2YtiLNPALCVxBCiUVq0LD1OQMxV/AdS/s7rLJU5o9i/jBZw/N4vXXL5dm29A==",
+      "peer": true
     },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.19"
+      }
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.13",
@@ -7131,18 +7310,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "node_modules/postcss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7915,6 +8082,21 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
+    "node_modules/stylelint-config-html": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
+      "integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
+      "engines": {
+        "node": "^12 || >=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "postcss-html": "^1.0.0",
+        "stylelint": ">=14.0.0"
+      }
+    },
     "node_modules/stylelint-config-recommended": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
@@ -7926,18 +8108,132 @@
         "stylelint": "^15.10.0"
       }
     },
-    "node_modules/stylelint-config-standard": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
-      "integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
+    "node_modules/stylelint-config-recommended-scss": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
+      "integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
       "dependencies": {
-        "stylelint-config-recommended": "^13.0.0"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "postcss-scss": "^4.0.6",
+        "stylelint-config-recommended": "^12.0.0",
+        "stylelint-scss": "^5.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^15.10.0"
+        "postcss": "^8.3.3",
+        "stylelint": "^15.5.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss/node_modules/stylelint-config-recommended": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss/node_modules/stylelint-scss": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
+      "integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
+      "dependencies": {
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.13",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.5.1 || ^15.0.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-vue": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-vue/-/stylelint-config-recommended-vue-1.5.0.tgz",
+      "integrity": "sha512-65TAK/clUqkNtkZLcuytoxU0URQYlml+30Nhop7sRkCZ/mtWdXt7T+spPSB3KMKlb+82aEVJ4OrcstyDBdbosg==",
+      "dependencies": {
+        "semver": "^7.3.5",
+        "stylelint-config-html": ">=1.0.0",
+        "stylelint-config-recommended": ">=6.0.0"
+      },
+      "engines": {
+        "node": "^12 || >=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "postcss-html": "^1.0.0",
+        "stylelint": ">=14.0.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-vue/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stylelint-config-recommended-vue/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stylelint-config-recommended-vue/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
+      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+      "dependencies": {
+        "stylelint-config-recommended": "^12.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-10.0.0.tgz",
+      "integrity": "sha512-bChBEo1p3xUVWh/wenJI+josoMk21f2yuLDGzGjmKYcALfl2u3DFltY+n4UHswYiXghqXaA8mRh+bFy/q1hQlg==",
+      "dependencies": {
+        "stylelint-config-recommended-scss": "^12.0.0",
+        "stylelint-config-standard": "^33.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3",
+        "stylelint": "^15.5.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint-config-standard/node_modules/stylelint-config-recommended": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+      "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+      "peerDependencies": {
+        "stylelint": "^15.5.0"
       }
     },
     "node_modules/stylelint-order": {
@@ -7952,33 +8248,6 @@
         "stylelint": "^14.0.0 || ^15.0.0"
       }
     },
-    "node_modules/stylelint-order/node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/stylelint-order/node_modules/postcss-sorting": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
@@ -7987,66 +8256,10 @@
         "postcss": "^8.4.20"
       }
     },
-    "node_modules/stylelint-scss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
-      "integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
-      "dependencies": {
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.13",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^14.5.1 || ^15.0.0"
-      }
-    },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
-    },
-    "node_modules/stylelint/node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/stylelint/node_modules/postcss-safe-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
     },
     "node_modules/stylelint/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -10026,6 +10239,24 @@
       "requires": {
         "globby": "11.x.x",
         "postcss": "7.x.x"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        }
       }
     },
     "@types/yargs": {
@@ -10759,6 +10990,43 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "peer": true,
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "peer": true
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "peer": true,
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "peer": true,
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.416",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.416.tgz",
@@ -10775,6 +11043,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "peer": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -11804,6 +12078,18 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
       "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="
+    },
+    "htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "peer": true,
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "human-signals": {
       "version": "2.1.0",
@@ -13824,36 +14110,56 @@
       }
     },
     "postcss": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
-      "dev": true,
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-html": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.5.0.tgz",
+      "integrity": "sha512-kCMRWJRHKicpA166kc2lAVUGxDZL324bkj/pVOb6RhjB0Z5Krl7mN0AsVkBhVIRZZirY0lyQXG38HCVaoKVNoA==",
+      "peer": true,
+      "requires": {
+        "htmlparser2": "^8.0.0",
+        "js-tokens": "^8.0.0",
+        "postcss": "^8.4.0",
+        "postcss-safe-parser": "^6.0.0"
       },
       "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+        "js-tokens": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-8.0.1.tgz",
+          "integrity": "sha512-3AGrZT6tuMm1ZWWn9mLXh7XMfi2YtiLNPALCVxBCiUVq0LD1OQMxV/AdS/s7rLJU5o9i/jBZw/N4vXXL5dm29A==",
+          "peer": true
         }
       }
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+    },
+    "postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "requires": {}
+    },
+    "postcss-scss": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.13",
@@ -14425,22 +14731,6 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
           "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
         },
-        "postcss": {
-          "version": "8.4.24",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-          "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-          "requires": {
-            "nanoid": "^3.3.6",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        },
-        "postcss-safe-parser": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-          "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-          "requires": {}
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -14462,18 +14752,103 @@
         }
       }
     },
+    "stylelint-config-html": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
+      "integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
+      "requires": {}
+    },
     "stylelint-config-recommended": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
       "integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
       "requires": {}
     },
-    "stylelint-config-standard": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
-      "integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
+    "stylelint-config-recommended-scss": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz",
+      "integrity": "sha512-5Bb2mlGy6WLa30oNeKpZvavv2lowJUsUJO25+OA68GFTemlwd1zbFsL7q0bReKipOSU3sG47hKneZ6Nd+ctrFA==",
       "requires": {
-        "stylelint-config-recommended": "^13.0.0"
+        "postcss-scss": "^4.0.6",
+        "stylelint-config-recommended": "^12.0.0",
+        "stylelint-scss": "^5.0.0"
+      },
+      "dependencies": {
+        "stylelint-config-recommended": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+          "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+          "requires": {}
+        },
+        "stylelint-scss": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
+          "integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
+          "requires": {
+            "postcss-media-query-parser": "^0.2.3",
+            "postcss-resolve-nested-selector": "^0.1.1",
+            "postcss-selector-parser": "^6.0.13",
+            "postcss-value-parser": "^4.2.0"
+          }
+        }
+      }
+    },
+    "stylelint-config-recommended-vue": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-vue/-/stylelint-config-recommended-vue-1.5.0.tgz",
+      "integrity": "sha512-65TAK/clUqkNtkZLcuytoxU0URQYlml+30Nhop7sRkCZ/mtWdXt7T+spPSB3KMKlb+82aEVJ4OrcstyDBdbosg==",
+      "requires": {
+        "semver": "^7.3.5",
+        "stylelint-config-html": ">=1.0.0",
+        "stylelint-config-recommended": ">=6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "stylelint-config-standard": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
+      "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+      "requires": {
+        "stylelint-config-recommended": "^12.0.0"
+      },
+      "dependencies": {
+        "stylelint-config-recommended": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
+          "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+          "requires": {}
+        }
+      }
+    },
+    "stylelint-config-standard-scss": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-10.0.0.tgz",
+      "integrity": "sha512-bChBEo1p3xUVWh/wenJI+josoMk21f2yuLDGzGjmKYcALfl2u3DFltY+n4UHswYiXghqXaA8mRh+bFy/q1hQlg==",
+      "requires": {
+        "stylelint-config-recommended-scss": "^12.0.0",
+        "stylelint-config-standard": "^33.0.0"
       }
     },
     "stylelint-order": {
@@ -14485,33 +14860,12 @@
         "postcss-sorting": "^8.0.2"
       },
       "dependencies": {
-        "postcss": {
-          "version": "8.4.24",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-          "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
-          "requires": {
-            "nanoid": "^3.3.6",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        },
         "postcss-sorting": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
           "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
           "requires": {}
         }
-      }
-    },
-    "stylelint-scss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.0.1.tgz",
-      "integrity": "sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==",
-      "requires": {
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.13",
-        "postcss-value-parser": "^4.2.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "url": "https://extensionengine.com"
   },
   "files": [
-    "rules"
+    "rules",
+    "base.js"
   ],
   "main": "index.js",
   "scripts": {
@@ -35,9 +36,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "stylelint-config-standard": "^34.0.0",
-    "stylelint-order": "^6.0.3",
-    "stylelint-scss": "^5.0.1"
+    "stylelint-config-recommended-vue": "^1.5.0",
+    "stylelint-config-standard-scss": "^10.0.0",
+    "stylelint-order": "^6.0.3"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.22.6",
@@ -58,6 +59,8 @@
     "stylelint": "^15.10.0"
   },
   "peerDependencies": {
+    "postcss-html": ">=1.5.0",
+    "postcss-scss": ">=4.0.6",
     "stylelint": ">=15.10.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "stylelint-order": "^6.0.3"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.22.6",
+    "@babel/eslint-parser": "^7.22.7",
     "@babel/eslint-plugin": "^7.22.5",
-    "@extensionengine/eslint-config": "^3.0.1",
+    "@extensionengine/eslint-config": "^4.0.0",
     "@types/stylelint": "^13.13.3",
     "eslint": "^8.44.0",
     "eslint-config-semistandard": "^17.0.0",
@@ -54,14 +54,14 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-vue": "^9.15.1",
-    "jest": "^29.6.0",
+    "jest": "^29.6.1",
     "jest-preset-stylelint": "^6.1.0",
-    "stylelint": "^15.10.0"
+    "stylelint": "^15.10.1"
   },
   "peerDependencies": {
     "postcss-html": ">=1.5.0",
     "postcss-scss": ">=4.0.6",
-    "stylelint": ">=15.10.0"
+    "stylelint": ">=15.10.1"
   },
   "publishConfig": {
     "access": "public"

--- a/rules/base.js
+++ b/rules/base.js
@@ -9,6 +9,7 @@ module.exports = {
       ignore: ['after-comment', 'inside-block']
     }],
     'function-name-case': 'lower',
+    'selector-class-pattern': null,
     'selector-pseudo-element-no-unknown': [true, {
       ignorePseudoElements: ['v-deep']
     }],


### PR DESCRIPTION
Starting with v14, Stylelint only supports linting CSS by default.
All other syntaxes need to be installed and configured separately.
This change introduces support for SCSS by extending the
`stylelint-config-standard-scss` shared config. This shared config
extends the `stylelint-config-standared` shared config and includes
the `stylelint-scss` plugin, and due to that they were removed as
direct dependencies.
Vue is supported by default by extending the `stylelint-config-recommended-vue`
shared config. The base config is introduced for cases when Vue is not needed.
Two new peer dependencies are introduced, `postcss-html` and `postcss-scss`.
Given what is stated above, this is a breaking change.